### PR TITLE
Made textarea only resizable vertically

### DIFF
--- a/_static/demo.css
+++ b/_static/demo.css
@@ -17,6 +17,7 @@
     padding: 2px;
     width: 100%;
     min-height: 150px;
+    resize: vertical;
 }
 
 #hlcode {


### PR DESCRIPTION
`<textarea>`s that are horizontally resizable are bad UX, so I disabled horizontal resizing.